### PR TITLE
Fix next_url link: must be filename only

### DIFF
--- a/src/ng2web/ng2web.py
+++ b/src/ng2web/ng2web.py
@@ -254,7 +254,7 @@ def write_entry(
                     else None
                 ),
                 next_url=(
-                    entry_file(guide, output_directory, entry.next, make_index)
+                    entry_file(guide, output_directory, entry.next, make_index).name
                     if entry.has_next
                     else None
                 ),


### PR DESCRIPTION
### TL;DR
Fixes the "next" link to point to the file in current dir, not the absolute path

